### PR TITLE
Allow for custom preprocessors which supply arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,40 @@ module.exports = function(config) {
 }
 ```
 
+If you need to process both, html and js, you can use karmas `customPreprocessors`:
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    customPreprocessors: {
+      preprocess_js: {
+        base: 'preprocess',
+        options: { type: 'js' }
+      },
+      preprocess_html: {
+        base: 'preprocess',
+        options: { type: 'html' }
+      }
+    },
+    preprocess: {
+      'src/js/**/*.js': ['preprocess_js'],
+      'src/templates/**/*.html': ['preprocess_html']
+    },
+
+    preprocessPreprocessor: {
+      // Context passed to preprocess plugin, can be a Function, URL string or an object
+      context: __dirname + '/my-context.json'
+    },
+
+    // make sure to include the .js files
+    files: [
+      'src/js/**/*.js'
+    ]
+  })
+}
+```
+
 ----
 
 For more information on Karma see the [karma] homepage.

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ function preprocessPreprocessor(args, config, helper) {
   return function(content, file, done) {
     config = config || {};
 
-    var options = config.options || args.options || {};
+    var options = helper.merge({}, config.options, args.options);
 
     var context = config.context;
 

--- a/index.js
+++ b/index.js
@@ -3,11 +3,11 @@
 var fs = require('fs');
 var pp = require('preprocess');
 
-function preprocessPreprocessor(config, helper) {
+function preprocessPreprocessor(args, config, helper) {
   return function(content, file, done) {
     config = config || {};
 
-    var options = config.options || {};
+    var options = config.options || args.options || {};
 
     var context = config.context;
 
@@ -37,7 +37,7 @@ function preprocessPreprocessor(config, helper) {
   };
 }
 
-preprocessPreprocessor.$inject = ['config.preprocessPreprocessor', 'helper'];
+preprocessPreprocessor.$inject = ['args', 'config.preprocessPreprocessor', 'helper'];
 
 module.exports = {
   'preprocessor:preprocess': ['factory', preprocessPreprocessor]


### PR DESCRIPTION
This change is necessary to preprocess both html and js files with this module, using karmas `customPreprocessors`-property:

```
    customPreprocessors: {
      preprocess_js: {
        base: 'preprocess',
        options: { type: 'js' }
      },
      preprocess_html: {
        base: 'preprocess',
        options: { type: 'html' }
      }
    },
    preprocess: {
      'src/js/**/*.js': ['preprocess_js'],
      'src/templates/**/*.html': ['preprocess_html']
    }
```
